### PR TITLE
#14 chore : @Repository 제거하여 Core에 springFrameWork 의존성 제거

### DIFF
--- a/src/main/java/com/sejong/newsletterservice/core/csknowledge/CsKnowledgeRepository.java
+++ b/src/main/java/com/sejong/newsletterservice/core/csknowledge/CsKnowledgeRepository.java
@@ -2,12 +2,10 @@ package com.sejong.newsletterservice.core.csknowledge;
 
 import com.sejong.newsletterservice.core.mailgategory.MailCategory;
 import com.sejong.newsletterservice.core.enums.MailCategoryName;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-@Repository
 public interface CsKnowledgeRepository {
     List<CsKnowledge> findAllByMailCategory(MailCategory mailCategory);
 

--- a/src/main/java/com/sejong/newsletterservice/core/mailgategory/MailCategoryRepository.java
+++ b/src/main/java/com/sejong/newsletterservice/core/mailgategory/MailCategoryRepository.java
@@ -1,11 +1,9 @@
 package com.sejong.newsletterservice.core.mailgategory;
 
 import com.sejong.newsletterservice.core.subscriber.Subscriber;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface MailCategoryRepository {
     Subscriber saveCategoriesTo(Subscriber subscriber, List<MailCategory> mailCategories);
 }

--- a/src/main/java/com/sejong/newsletterservice/core/sentlog/SentLogRepository.java
+++ b/src/main/java/com/sejong/newsletterservice/core/sentlog/SentLogRepository.java
@@ -1,10 +1,7 @@
 package com.sejong.newsletterservice.core.sentlog;
 
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 
-@Repository
 public interface SentLogRepository {
     boolean existsByEmailAndCsKnowledgeId(String email, Long csKnowledgeId);
     void save(SentLog sentLog);

--- a/src/main/java/com/sejong/newsletterservice/core/subscriber/SubscriberRepository.java
+++ b/src/main/java/com/sejong/newsletterservice/core/subscriber/SubscriberRepository.java
@@ -1,11 +1,9 @@
 package com.sejong.newsletterservice.core.subscriber;
 
 import com.sejong.newsletterservice.core.enums.EmailFrequency;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface SubscriberRepository {
     List<Subscriber> findByEmailFrequency(EmailFrequency frequency);
 }


### PR DESCRIPTION
## #️⃣ 이슈

- close #14 


## 🔎 작업 내용
Core 패키지내에서 관련 @Repository로 인해 SpringFrameWork 의존성이 부여되었습니다. 
해당 부분을 삭제하여 의존성을 제거 했습니다. 


## 🤔 고민해볼 부분 & 코드 리뷰 희망사항
```
package com.sejong.newsletterservice.core.subscriber.vo;

import com.fasterxml.jackson.annotation.JsonTypeInfo;
import com.sejong.newsletterservice.core.enums.EmailFrequency;
import com.sejong.newsletterservice.core.enums.MailCategoryName;

import java.io.Serializable;
import java.util.List;

@JsonTypeInfo(
        use = JsonTypeInfo.Id.CLASS,
        include = JsonTypeInfo.As.PROPERTY,
        property = "@class"
)
public record SubscriberRequestVO(
        String email,
        EmailFrequency emailFrequency,
        List<MailCategoryName> selectedCategories,
        String code
) implements Serializable {
    public SubscriberRequestVO {
        if (email == null || email.isBlank()) {
            throw new IllegalArgumentException("이메일은 반드시 입력해야 됩니다.");
        }
        if (selectedCategories == null || selectedCategories.isEmpty()) {
            throw new IllegalArgumentException("category는 반드시 하나는 선택해야 됩니다.");
        }
    }
}
```
위의 코드 직렬화 역직렬화 로 인해 해당 부분 외부 의존성이 생겼는데 
위와 관련해서 논의하고 싶어요

## 🧲 참고 자료 및 공유 사항


